### PR TITLE
Better force torque model

### DIFF
--- a/include/quad_sim/motorTq.hpp
+++ b/include/quad_sim/motorTq.hpp
@@ -3,6 +3,6 @@
 #ifndef __MOTOR_TQ_HEADER__
 #define __MOTOR_TQ_HEADER__
 
-double motTq(double u, double V, double motRll, double motKv);
+double motTq(bool ccwMotor, double u, double V, double motRll, double motKv);
 
 #endif // __MOTOR_TQ_HEADER__

--- a/include/quad_sim/propThTq.hpp
+++ b/include/quad_sim/propThTq.hpp
@@ -19,6 +19,6 @@ void fitPropData(std::filesystem::path propDataDir);
 
 double getAirDensity(double alt);
 
-void getPropThTq(double u, double alt, double propVel, double propDia, double g, double &th, double &tq);
+void getPropThTq(bool ccwProp, double u, double alt, double propVel, double propDia, double g, double &th, double &tq);
 
 #endif // __PROP_TH_TQ_HEADER__

--- a/scripts/eomGenerator.py
+++ b/scripts/eomGenerator.py
@@ -108,10 +108,10 @@ fVals = sympy.MatrixSymbol("fVals", 4, 1); # fVals = [fB; fC; fD; fE]
 tVals = sympy.MatrixSymbol("tVals", 4, 1); # tVals = [tB; tC; tD; tE]
 FList = [(Ao,-g*A.mass*N123.z),(Bo,-g*B.mass*N123.z),(Co,-g*C.mass*N123.z),(Do,-g*D.mass*N123.z),(Eo,-g*E.mass*N123.z),
          (Bo,fVals[0]*A123.z),(Co,fVals[1]*A123.z),(Do,fVals[2]*A123.z),(Eo,fVals[3]*A123.z)];
-TList = [(A123, tVals[0]*A123.z - tVals[1]*A123.z + tVals[2]*A123.z - tVals[3]*A123.z),\
-         (B123,-tVals[0]*A123.z),\
+TList = [(A123, - tVals[0]*A123.z - tVals[1]*A123.z - tVals[2]*A123.z - tVals[3]*A123.z),\
+         (B123, tVals[0]*A123.z),\
          (C123, tVals[1]*A123.z),\
-         (D123,-tVals[2]*A123.z),\
+         (D123, tVals[2]*A123.z),\
          (E123, tVals[3]*A123.z)];
 FL = FList + TList;
 

--- a/src/motorTq.cpp
+++ b/src/motorTq.cpp
@@ -1,7 +1,8 @@
 #include <quad_sim/motorTq.hpp>
 
-double motTq(double u, double V, double motRll, double motKv)
+double motTq(bool ccwMotor, double u, double V, double motRll, double motKv)
 {
+    // ccwMotor = True if the motor rotates in CCW direction when V is positive.
     // u = current angular velocity of the motor in rad/sec
     // V = Voltage applied
     // motRll = Line-To-Line resistance of the motor winding
@@ -22,9 +23,6 @@ double motTq(double u, double V, double motRll, double motKv)
     // Define necessary variables
     double Rphi, Kt, Kb;
 
-    // The motors are assumed to be rotating in one direction only
-    u = abs(u);
-
     // Define conversion factor for rad/sec to revs/min
     const double radpsec2revpmin = 9.5492968;
 
@@ -39,6 +37,9 @@ double motTq(double u, double V, double motRll, double motKv)
 
     Kb = Kt;
 
+    // Account for rotation direction
+    V *= ccwMotor ? 1 : -1;
+    
     // Calculate the torque produced by the motor
     return Kt * (V - Kb * u * radpsec2revpmin) / Rphi;
 }

--- a/src/solve_physics.cpp
+++ b/src/solve_physics.cpp
@@ -68,9 +68,9 @@ int main(int argc, char **argv)
         double th, tq;
         for (size_t i = 0; i < 4; ++i)
         {
-            getPropThTq(quad.q[17 + i], quad.q[2], propVels(i), quad.propDia, quad.g, th, tq); // Thrust and torque on motor B
+            getPropThTq((i & 1), quad.q[17 + i], quad.q[2], propVels(i), quad.propDia, quad.g, th, tq); // Thrust and torque on motor B
             quad.fVals[i] = th;
-            quad.tVals[i] = ((i & 1) ? -1 : 1) * tq;
+            quad.tVals[i] = tq;
         }
 
         // Get control signal, motor voltages from esc signals

--- a/src/solve_physics.cpp
+++ b/src/solve_physics.cpp
@@ -70,7 +70,7 @@ int main(int argc, char **argv)
         {
             getPropThTq(quad.q[17 + i], quad.q[2], propVels(i), quad.propDia, quad.g, th, tq); // Thrust and torque on motor B
             quad.fVals[i] = th;
-            quad.tVals[i] = -tq;
+            quad.tVals[i] = ((i & 1) ? -1 : 1) * tq;
         }
 
         // Get control signal, motor voltages from esc signals
@@ -79,7 +79,7 @@ int main(int argc, char **argv)
 
         // Apply motor torques based on the calculated motor voltage
         for (size_t i = 0; i < 4; ++i)
-            quad.tVals[i] += motTq(quad.q[17 + i], motVolts[i], quad.motRll, quad.motKv);
+            quad.tVals[i] += motTq((i & 1), quad.q[17 + i], motVolts[i], quad.motRll, quad.motKv);
 
         // Get the arming state of the quadcopter
         int64_t armStateTS;


### PR DESCRIPTION
The old force and torque models for motor and propeller were dependent on the fact that the equations of motion accounted for the appropriate direction of propeller and motor rotation. The code implemented here lets the equation of motion define the force and torques on bodies in positive direction and then applies the appropriate signs in the force and torque calculation functions.